### PR TITLE
Added the changes to get primary revision based on bucket size

### DIFF
--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -1,6 +1,6 @@
 {
     "ConsistentHash": "rendezvous",
-    "BucketSize": 2,
+    "BucketSize": 10,
     "StoreType": "redis",
     "Stores": [
         {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,7 @@ type KVConfiguration struct {
 	ConsistentHash string
 	StoreType      string
 	Stores         []KVStore
-	BucketSize     int
+	BucketSize     int64
 }
 type KVStore struct {
 	Name string

--- a/pkg/index/revision.go
+++ b/pkg/index/revision.go
@@ -42,6 +42,12 @@ func NewRevision(main, sub int64) Revision {
 func (a Revision) String() string {
 	return fmt.Sprintf("%d", a.main)
 }
+func (a Revision) GetMain() int64 {
+	return a.main
+}
+func (a Revision) GetSub() int64 {
+	return a.sub
+}
 func (a Revision) GreaterThan(b Revision) bool {
 	if a.main > b.main {
 		return true


### PR DESCRIPTION
The change is to use the primary revision in a bucket to locate a store node instead of the revision itself.

A revision is divided by the predefined bucket size in the config file. Therefore, all the revisions starting from the primary revision to the primary revision + bucket size - 1 are saved in the same datastore. 

A method of getPrimaryRevBytesWithBucket is added and is called before we locate a node using revisions.