### PR TITLE
minor: use make to build in start_kv script

### DIFF
--- a/scripts/start_kv.sh
+++ b/scripts/start_kv.sh
@@ -2,6 +2,6 @@
 
 [[ -n "${RKV_PID-}" ]] && sudo kill "${RKV_PID[@]}" 2>/dev/null
 
-go run cmd/http/main.go
+make
+./main &
 export RKV_PID=$!
-


### PR DESCRIPTION
minor script change - start_kv.sh script uses make to build, and run the built main in background 