### PR TITLE
trivial: ycsb client uses new ami having output suppressed

### DIFF
--- a/scripts/test-lab.val
+++ b/scripts/test-lab.val
@@ -38,7 +38,7 @@ export JAEGER_VM_NAME=${NAME_TAG}-rkv-lab-jaeger
 ## of prometheus server
 
 ## of go-ycsb client
-export YCSB_AMI=ami-0aba4f5641629766e     #hw-ami-go-ycsb2
+export YCSB_AMI=ami-02d2e1ae9f75eab06       #hw-ami-go-ycsb4
 export YCSB_INSTANCE_TYPE=t2.micro
 export YCSB_ROOT_DISK_VOLUME=16
 export YCSB_VM_NAME=${NAME_TAG}-rkv-lab-ycsb


### PR DESCRIPTION
trivial change - perf test lab go-ycsb client would use new AMI that has rkv driver code change to suppress excessive logs to stdout