### PR TITLE
perf test script to use go-ycsb ami including read_error fix

### DIFF
--- a/scripts/setup_test_lab.sh
+++ b/scripts/setup_test_lab.sh
@@ -125,6 +125,7 @@ print_green "tests can be fired up against rkv service now"
 ## todo: run more workloads
 #
 echo "firing a test, log in /tmp/ycsb-a.log"
-ssh -i ${KEY_FILE} ubuntu@${ycsb_vmip} -o "StrictHostKeyChecking no" "cd work/go-ycsb && ./bin/go-ycsb load rkv -P workloads/workloada" > /tmp/ycsb-a.log 2>&1
+ssh -i ${KEY_FILE} ubuntu@${ycsb_vmip} -o "StrictHostKeyChecking no" "cd work/go-ycsb && ./bin/go-ycsb load rkv -P workloads/workloada" > /tmp/ycsb-load-a.log 2>&1
+ssh -i ${KEY_FILE} ubuntu@${ycsb_vmip} -o "StrictHostKeyChecking no" "cd work/go-ycsb && ./bin/go-ycsb run rkv -P workloads/workloada" > /tmp/ycsb-run-a.log 2>&1
 
 print_green "jaeger tracing at http://${jaeger_vmip}:16686"

--- a/scripts/test-lab.val
+++ b/scripts/test-lab.val
@@ -38,7 +38,7 @@ export JAEGER_VM_NAME=${NAME_TAG}-rkv-lab-jaeger
 ## of prometheus server
 
 ## of go-ycsb client
-export YCSB_AMI=ami-02d2e1ae9f75eab06       #hw-ami-go-ycsb4
+export YCSB_AMI=ami-03fadfb192c131dc0      #hw-ami-go-ycsb5
 export YCSB_INSTANCE_TYPE=t2.micro
 export YCSB_ROOT_DISK_VOLUME=16
 export YCSB_VM_NAME=${NAME_TAG}-rkv-lab-ycsb

--- a/scripts/test_infra/create_test_instances.sh
+++ b/scripts/test_infra/create_test_instances.sh
@@ -40,6 +40,7 @@ install_redis_fn() {
 configure_redis_fn() {
     sudo sed -i 's/^bind 127.0.0.1 ::1/#bind 127.0.0.1 ::1/' /etc/redis/redis.conf
     sudo sed -i 's/protected-mode yes/protected-mode no/' /etc/redis/redis.conf
+    sudo sed -i 's/port 6379/port 6666/' /etc/redis/redis.conf
     sudo sudo systemctl restart redis
 }
 
@@ -163,7 +164,7 @@ setup_config() {
     do
         inner=$(jq -n --arg name "si-$ip" \
     	    --arg host $ip \
-    	    --argjson port 6379 \
+          --argjson port 6666 \
     	    '{"Name": $name, "Host": $host, "Port": $port}'
         )
         config="$(jq --argjson val "$inner" '.Stores += [$val]' <<< "$config")"


### PR DESCRIPTION
this PR includes a few fixes to perf test script
1. go-ycsb client to use new ami that includes rkv read_error fix;
2. exemplified workload-a test to include __run__ phase;
3. redis backend avoids the defauklt 6379 port .

Verified by running setup_test_lab.sh and look at /tmp/ycsb-run-a.log
```
...
**********************************************
Run finished, takes 3.901725553s
READ   - Takes(s): 3.9, Count: 501, OPS: 129.0, Avg(us): 2824, Min(us): 2033, Max(us): 16055, 99th(us): 11895, 99.9th(us): 15327, 99.99th(us): 16055
UPDATE - Takes(s): 3.9, Count: 499, OPS: 128.1, Avg(us): 4957, Min(us): 3758, Max(us): 24927, 99th(us): 16023, 99.9th(us): 24927, 99.99th(us): 24927
```