### PR TITLE
minor: perf test tool - disable save to disk for all redis backend

### DIFF
--- a/scripts/test_infra/create_test_instances.sh
+++ b/scripts/test_infra/create_test_instances.sh
@@ -41,6 +41,9 @@ configure_redis_fn() {
     sudo sed -i 's/^bind 127.0.0.1 ::1/#bind 127.0.0.1 ::1/' /etc/redis/redis.conf
     sudo sed -i 's/protected-mode yes/protected-mode no/' /etc/redis/redis.conf
     sudo sed -i 's/port 6379/port 6666/' /etc/redis/redis.conf
+    sudo sed -i 's/^save \d*/# save /' /etc/redis/redis.conf
+    sudo sed -i 's/^#\W*save ""/save ""/' /etc/redis/redis.conf
+
     sudo sudo systemctl restart redis
 }
 


### PR DESCRIPTION
it PR disables redis save to disk feature in perf test lab.

Disabling save disk helps to avoid rkv crash when redis resource is exhausted by massive records.