### PR TITLE
Added concurrent mode to improve performance

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         go version
-        go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
         go get github.com/gomodule/redigo/redis
         go get github.com/google/btree
     - name: Run build

--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -3,6 +3,7 @@
     "BucketSize": 10,
     "ReplicaNum": 2,
     "StoreType": "redis",
+    "Concurrent": true,
     "Stores": [
         {
             "Name": "store1",

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -100,7 +100,7 @@ func NewKeyValueHandler(conf config.KVConfiguration) *KeyValueHandler {
 		nodes := store + "," + strings.Join(rs, ",")
 		ring.AddNode(testNode(nodes))
 	}
-	piping := piping.NewChainPiping(conf.StoreType, ca.LINEARIZABLE)
+	piping := piping.NewChainPiping(conf.StoreType, ca.LINEARIZABLE, conf.Concurrent)
 	return &KeyValueHandler{ch: ring, conf: conf, indexTree: index.NewTreeIndex(), piping: piping}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type KVConfiguration struct {
 	Stores         []KVStore
 	BucketSize     int64
 	ReplicaNum     int
+	Concurrent     bool
 }
 type KVStore struct {
 	Name string

--- a/pkg/consistent/chain/node.go
+++ b/pkg/consistent/chain/node.go
@@ -65,3 +65,7 @@ func (n *ChainNode) GetID() int {
 func (n *ChainNode) GetNext() *ChainNode {
 	return n.next
 }
+
+func (n *ChainNode) GetDB() database.Database {
+	return n.db
+}

--- a/pkg/piping/chain_piping_manager.go
+++ b/pkg/piping/chain_piping_manager.go
@@ -2,21 +2,24 @@ package piping
 
 import (
 	"context"
+	"sync"
 
 	"github.com/regionless-storage-service/pkg/config"
 	"github.com/regionless-storage-service/pkg/consistent"
 	"github.com/regionless-storage-service/pkg/consistent/chain"
 	"github.com/regionless-storage-service/pkg/index"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 )
 
 type ChainPiping struct {
 	databaseType string
 	consistency  consistent.CONSISTENCY
+	concurrent   bool
 }
 
-func NewChainPiping(databaseType string, consistency consistent.CONSISTENCY) *ChainPiping {
-	return &ChainPiping{databaseType: databaseType, consistency: consistency}
+func NewChainPiping(databaseType string, consistency consistent.CONSISTENCY, concurrent bool) *ChainPiping {
+	return &ChainPiping{databaseType: databaseType, consistency: consistency, concurrent: concurrent}
 }
 
 func (c *ChainPiping) Read(ctx context.Context, rev index.Revision) (string, error) {
@@ -40,24 +43,61 @@ func (c *ChainPiping) ReadTail(ctx context.Context, rev index.Revision) (string,
 }
 
 func (c *ChainPiping) Write(ctx context.Context, rev index.Revision, val string) error {
-
-	chain, err := chain.NewChain(ctx, c.databaseType, rev.GetNodes())
+	nodeChains, err := chain.NewChain(ctx, c.databaseType, rev.GetNodes())
 	if err != nil {
 		return err
 	}
 	_, rootSpan := otel.Tracer(config.TraceName).Start(ctx, "chain write")
 	defer rootSpan.End()
-	chain.Write(rev.String(), val, c.consistency)
+	if c.concurrent {
+		var wg sync.WaitGroup
+		p := nodeChains.GetHead()
+		for p != nil {
+			wg.Add(1)
+			go func(ctx context.Context, node *chain.ChainNode, key, val string) {
+				defer wg.Done()
+				_, rootSpan := otel.Tracer(config.TraceName).Start(ctx, "db put")
+				defer rootSpan.End()
+				if _, err := node.GetDB().Put(key, val); err != nil {
+					rootSpan.RecordError(err)
+					rootSpan.SetStatus(codes.Error, err.Error())
+				}
+			}(ctx, p, rev.String(), val)
+			p = p.GetNext()
+		}
+		wg.Wait()
+	} else {
+		nodeChains.Write(rev.String(), val, c.consistency)
+	}
 	return nil
 }
 
 func (c *ChainPiping) Delete(ctx context.Context, rev index.Revision) error {
-	chain, err := chain.NewChain(ctx, c.databaseType, rev.GetNodes())
+	nodeChains, err := chain.NewChain(ctx, c.databaseType, rev.GetNodes())
 	if err != nil {
 		return err
 	}
 	_, rootSpan := otel.Tracer(config.TraceName).Start(ctx, "chain delete")
 	defer rootSpan.End()
-	chain.Delete(rev.String(), c.consistency)
+	if c.concurrent {
+		var wg sync.WaitGroup
+		p := nodeChains.GetHead()
+		for p != nil {
+			wg.Add(1)
+			go func(ctx context.Context, node *chain.ChainNode, key string) {
+				defer wg.Done()
+				_, rootSpan := otel.Tracer(config.TraceName).Start(ctx, "db delete")
+				defer rootSpan.End()
+				if err := node.GetDB().Delete(key); err != nil {
+					rootSpan.RecordError(err)
+					rootSpan.SetStatus(codes.Error, err.Error())
+				}
+			}(ctx, p, rev.String())
+			p = p.GetNext()
+		}
+		wg.Wait()
+	} else {
+		nodeChains.Delete(rev.String(), c.consistency)
+	}
 	return nil
 }

--- a/test/piping/chain_piping_manager_test.go
+++ b/test/piping/chain_piping_manager_test.go
@@ -10,15 +10,58 @@ import (
 )
 
 func TestWriteLINEARIZABLE(t *testing.T) {
-	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE)
+	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, false)
 	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"})
 	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
 		t.Fatalf("fail to write with the error %v", err)
 	}
 }
 
+func TestDeleteLINEARIZABLE(t *testing.T) {
+	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, false)
+	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"})
+	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
+		t.Fatalf("fail to write with the error %v", err)
+	}
+	if err := cp.Delete(context.TODO(), rev); err != nil {
+		t.Fatalf("fail to write with the error %v", err)
+	}
+}
+
 func TestReadLINEARIZABLE(t *testing.T) {
-	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE)
+	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, false)
+	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2"})
+	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
+		t.Fatalf("fail to write with the error %v", err)
+	}
+	if val, err := cp.Read(context.TODO(), rev); err != nil {
+		t.Fatalf("fail to read with the error %v", err)
+	} else if val != "v" {
+		t.Fatalf("read a wrong value %s", val)
+	}
+}
+
+func TestWriteLINEARIZABLEConcurrently(t *testing.T) {
+	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, true)
+	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"})
+	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
+		t.Fatalf("fail to write with the error %v", err)
+	}
+}
+
+func TestDeleteLINEARIZABLEConcurrently(t *testing.T) {
+	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, true)
+	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"})
+	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
+		t.Fatalf("fail to write with the error %v", err)
+	}
+	if err := cp.Delete(context.TODO(), rev); err != nil {
+		t.Fatalf("fail to write with the error %v", err)
+	}
+}
+
+func TestReadLINEARIZABLEConcurrently(t *testing.T) {
+	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, true)
 	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2"})
 	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
 		t.Fatalf("fail to write with the error %v", err)


### PR DESCRIPTION
A new flag concurrent  is added to config.json

If it is set to true, all the delete/write operations to chain nodes will be triggered concurrent  to improve performance.
![image](https://user-images.githubusercontent.com/50841010/183470561-367a8cbf-d9ea-4989-b267-0df20ff5b6ea.png)

If it is set to false, all the delete/write operations to chain nodes will be triggered in a sequence as usual. 
![image](https://user-images.githubusercontent.com/50841010/183470921-de34c62b-ebf4-4467-bd05-53e5bf686871.png)

The total performance has been improved from 3.49ms to 1.18ms as expected.

