### PR TITLE
jaeger probabilistic sampler

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -30,9 +32,12 @@ import (
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	// -trace-env="onebox-730", for instance, is a good name for 730 milestone, one-box rkv system
 	flag.StringVar(&config.TraceEnv, "trace-env", config.DefaultTraceEnv, "environment name displayed in tracing system")
 	jaegerServer := flag.String("jaeger-server", "http://localhost:14268", "jaeger server endpoint in form of http://host-ip:port")
+	flag.Float64Var(&config.TraceSamplingRate, "trace-sampling-rate", 1.0, "optional sampling rate")
 	flag.Parse()
 	if len(config.TraceEnv) != 0 {
 		// for now, only support http protocol of jaeger service

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -32,6 +32,9 @@ import (
 )
 
 func main() {
+	// For now, we use the current time as seed for each configuration. However, we might notice that
+	// it will give a deterministic sequence of pseudo-random numbers as the code shows according to
+	// its implementation https://github.com/golang/go/blob/master/src/math/rand/rng.go#L25
 	rand.Seed(time.Now().UnixNano())
 
 	// -trace-env="onebox-730", for instance, is a good name for 730 milestone, one-box rkv system

--- a/cmd/http/tracer.go
+++ b/cmd/http/tracer.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	"math"
 	"math/rand"
 )
 
@@ -62,9 +63,8 @@ func (s ProbabilisticSampler) Description() string {
 }
 
 func NewProbabilisticSampler(probability float64) *ProbabilisticSampler {
-	const MAX = 1000.0
-	boundary := MAX * probability
-	return &ProbabilisticSampler{MAX, int(boundary)}
+	boundary := math.MaxInt32 * probability
+	return &ProbabilisticSampler{math.MaxInt32, int(boundary)}
 }
 
 var _ trace.Sampler = NewProbabilisticSampler(0.001)

--- a/cmd/http/tracer.go
+++ b/cmd/http/tracer.go
@@ -62,9 +62,9 @@ func (s ProbabilisticSampler) Description() string {
 }
 
 func NewProbabilisticSampler(probability float64) *ProbabilisticSampler {
-	const max = 1000.0
-	boundary := max * probability
-	return &ProbabilisticSampler{max, int(boundary)}
+	const MAX = 1000.0
+	boundary := MAX * probability
+	return &ProbabilisticSampler{MAX, int(boundary)}
 }
 
 var _ trace.Sampler = NewProbabilisticSampler(0.001)

--- a/cmd/http/tracer.go
+++ b/cmd/http/tracer.go
@@ -7,9 +7,17 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"math/rand"
 )
 
 func tracerProvider(url string) (*trace.TracerProvider, error) {
+	// default sampler is the always-on
+	var sampler trace.Sampler
+	if config.TraceSamplingRate < 1.0 { // use the custom probability sampler to reduce the trace samples
+		sampler = trace.ParentBased(NewProbabilisticSampler(config.TraceSamplingRate))
+	}
+
 	// Create the Jaeger exporter
 	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
 	if err != nil {
@@ -24,6 +32,39 @@ func tracerProvider(url string) (*trace.TracerProvider, error) {
 			semconv.ServiceNameKey.String(config.TraceName),
 			attribute.String("environment", config.TraceEnv),
 		)),
+		trace.WithSampler(sampler),
 	)
 	return tp, nil
 }
+
+type ProbabilisticSampler struct {
+	max      int
+	boundary int // values equal or greater than boundary would be dropped; 1/00 prob can be expressed as max=100, boundary=1
+}
+
+func (s ProbabilisticSampler) ShouldSample(p trace.SamplingParameters) trace.SamplingResult {
+	r := rand.Intn(s.max)
+	if r >= s.boundary {
+		return trace.SamplingResult{
+			Decision:   trace.Drop,
+			Tracestate: oteltrace.SpanContextFromContext(p.ParentContext).TraceState(),
+		}
+	}
+
+	return trace.SamplingResult{
+		Decision:   trace.RecordAndSample,
+		Tracestate: oteltrace.SpanContextFromContext(p.ParentContext).TraceState(),
+	}
+}
+
+func (s ProbabilisticSampler) Description() string {
+	return "probabilistic sampler"
+}
+
+func NewProbabilisticSampler(probability float64) *ProbabilisticSampler {
+	const max = 1000.0
+	boundary := max * probability
+	return &ProbabilisticSampler{max, int(boundary)}
+}
+
+var _ trace.Sampler = NewProbabilisticSampler(0.001)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,8 @@ const (
 )
 
 var (
-	TraceEnv string
+	TraceEnv          string
+	TraceSamplingRate float64
 )
 
 type KVConfiguration struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"runtime"
 	"strings"
-	"time"
 )
 
 const (
@@ -37,10 +36,6 @@ type KVStore struct {
 }
 
 func NewKVConfiguration(fileName string) (KVConfiguration, error) {
-	// For now, we use the current time as seed for each configuration. However, we might notice that
-	// it will give a deterministic sequence of pseudo-random numbers as the code shows according to
-	// its implementation https://github.com/golang/go/blob/master/src/math/rand/rng.go#L25
-	rand.Seed(time.Now().UnixNano())
 	_, runningfile, _, ok := runtime.Caller(1)
 	configuration := KVConfiguration{}
 	if !ok {


### PR DESCRIPTION
This PR introduces a jaeger probabilistic sampler to RKV.

Probabilistic sampler, when in use to replace the default always-on sampler, would be able to reduce the amount of tracing data sent to jaeger backend. This helps to mitigate the issue of too much tracing data in massive perf test.

Probabilistic sampler is optional. By default rkv still uses the always-on. When command line arg, e.g. --trace-sampling-rate=0.01, is specified, rkv would use the probabilistic sample (1/100 samples would be traced in the case).