### PR TITLE
refactor: index and tree-index to have context as method arg

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -31,7 +31,6 @@ func NewTreeIndex() Index {
 }
 
 // Put inserts a new index entry
-// for now, assuming no error yield within this method
 // todo: return applicable errors, if any
 func (ti *treeIndex) Put(ctx context.Context, key []byte, rev Revision) error {
 	// tracing indexing component - updating index
@@ -125,7 +124,7 @@ func (ti *treeIndex) Range(key, end []byte, atRev int64) (keys [][]byte, revs []
 }
 
 func (ti *treeIndex) Tombstone(ctx context.Context, key []byte, rev Revision) error {
-	// tracing indexing component - deleting index entry (as tombstone)
+	// tracing indexing component - mark index entry as tombstone
 	_, span := otel.Tracer(config.TraceName).Start(ctx, "tombstone index")
 	defer span.End()
 
@@ -146,7 +145,7 @@ func (ti *treeIndex) Tombstone(ctx context.Context, key []byte, rev Revision) er
 // at or after the given rev. The returned slice is sorted in the order
 // of Revision.
 func (ti *treeIndex) RangeSince(ctx context.Context, key, end []byte, rev int64) []Revision {
-	// tracing indexing component - ranged query of  index
+	// tracing indexing component - range query of  index
 	_, span := otel.Tracer(config.TraceName).Start(ctx, "rangesince kv")
 	defer span.End()
 

--- a/pkg/index/key_index.go
+++ b/pkg/index/key_index.go
@@ -59,6 +59,7 @@ type keyIndex struct {
 	generations []generation
 }
 
+// todo: return error instead to panic
 // put puts a Revision to the keyIndex.
 func (ki *keyIndex) put(main int64, sub int64, nodes []string) {
 	rev := Revision{main: main, sub: sub, nodes: nodes}


### PR DESCRIPTION
this PR is almost pure refactoring; not new feature nor bug fix.

* unifies index interface and tree_index impl method signature to have context as first arg (except for Equal which is not very clear its future use yet);
* adds Put return of error.
