### PR TITLE
create storages once

### DIFF
--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -2,7 +2,7 @@
     "ConsistentHash": "rendezvous",
     "BucketSize": 10,
     "ReplicaNum": 3,
-    "StoreType": "redis",
+    "StoreType": "mem",
     "Concurrent": true,
     "Stores": [
         {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,9 @@ const (
 var (
 	TraceEnv          string
 	TraceSamplingRate float64
+
+	// RKVConfig keeps rkv configuration parsed from config.json
+	RKVConfig *KVConfiguration
 )
 
 type KVConfiguration struct {
@@ -35,9 +38,9 @@ type KVStore struct {
 	Port       int
 }
 
-func NewKVConfiguration(fileName string) (KVConfiguration, error) {
+func NewKVConfiguration(fileName string) (*KVConfiguration, error) {
 	_, runningfile, _, ok := runtime.Caller(1)
-	configuration := KVConfiguration{}
+	configuration := &KVConfiguration{}
 	if !ok {
 		return configuration, fmt.Errorf("failed to open the given config file %s", fileName)
 	}
@@ -62,11 +65,11 @@ func (c *KVConfiguration) GetReplications() []string {
 	for _, store := range c.Stores {
 		switch region := store.RegionType; region {
 		case "local":
-			localStores = append(localStores, fmt.Sprintf("%s:%d", store.Host, store.Port))
+			localStores = append(localStores, store.Name)
 		case "neighbor":
-			neighborStores = append(neighborStores, fmt.Sprintf("%s:%d", store.Host, store.Port))
+			neighborStores = append(neighborStores, store.Name)
 		case "remote":
-			remoteStores = append(remoteStores, fmt.Sprintf("%s:%d", store.Host, store.Port))
+			remoteStores = append(remoteStores, store.Name)
 		}
 	}
 	n := len(localStores)

--- a/pkg/consistent/chain/chain.go
+++ b/pkg/consistent/chain/chain.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 
 	"github.com/regionless-storage-service/pkg/config"
@@ -28,10 +29,11 @@ func NewChain(ctx context.Context, nodeType string, nodes []string) (*Chain, err
 	}
 	dbs := make([]database.Database, n)
 	for i := 0; i < n; i++ {
-		if db, err := database.Factory(nodeType, nodes[i]); err == nil {
+		db, ok := database.Storages[nodes[i]]
+		if ok {
 			dbs[i] = db
 		} else {
-			return nil, err
+			return nil, fmt.Errorf("storage not found for %s", nodes[i])
 		}
 	}
 	return NewChainWithDatbases(ctx, dbs), nil

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,18 +1,15 @@
 package database
 
+var (
+	// Storages keeps all backend storages indexed by name
+	Storages map[string]Database = make(map[string]Database)
+)
+
 type Database interface {
 	Put(key, value string) (string, error)
 	Get(key string) (string, error)
 	Delete(key string) error
 	Close() error
-}
-
-type KeyValue struct {
-	key             []byte
-	create_revision int64
-	mod_revision    int64
-	version         int64
-	value           []byte
 }
 
 func Factory(databaseType, databaseUrl string) (Database, error) {

--- a/pkg/database/redis.go
+++ b/pkg/database/redis.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/regionless-storage-service/pkg/config"
 )
 
-var pools map[string]*redis.Pool
+var (
+	pools    map[string]*redis.Pool
+	initOnce sync.Once
+)
 
 func InitStorageInstancePool(stores []config.KVStore) {
 	pools = make(map[string]*redis.Pool)
@@ -45,6 +49,9 @@ type RedisDatabase struct {
 }
 
 func createRedisDatabase(databaseUrl string) (Database, error) {
+	initOnce.Do(func() {
+		InitStorageInstancePool(config.RKVConfig.Stores)
+	})
 	return &RedisDatabase{client: pools[databaseUrl]}, nil
 }
 


### PR DESCRIPTION
this PR focuses following items:
1. change config.json storage type default to "mem", so to facilitate local development and test;
2. keep all backend storage object in global cache, so to avoid creating on every op, by store name (not by host:port)

It is preliminary change for the PR introducing dummy database type (which is coming soon on top of this).

## Verification it works
Verifying is relatively easy: simply start rkv (be default it uses mem database), and using curl to insert/read k-v pairs.
```bash
curl -X POST http://127.0.0.1:8090/kv -d '{"key":"a","value":"111"}'
curl http://127.0.0.1:8090/kv?key=a
```