### PR TITLE
introduces dummy+latency store type suitable as simulator used in perf test

### DIFF
--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -9,19 +9,22 @@
             "RegionType": "local",
             "Name": "store1",
             "Host": "127.0.0.1",
-            "Port": 6379
+            "Port": 6379,
+            "ArtificialLatencyMs": 1
         },
         {
             "RegionType": "neighbor",
             "Name": "store3",
             "Host": "172.31.9.140",
-            "Port": 6379
+            "Port": 6379,
+            "ArtificialLatencyMs": 40
         },
         {
             "RegionType": "remote",
             "Name": "store4",
             "Host": "172.31.12.96",
-            "Port": 6380
+            "Port": 6380,
+            "ArtificialLatencyMs": 100
         }
     ]
 }

--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -10,21 +10,21 @@
             "Name": "store1",
             "Host": "127.0.0.1",
             "Port": 6379,
-            "ArtificialLatencyMs": 1
+            "ArtificialLatencyInMs": 1
         },
         {
             "RegionType": "neighbor",
             "Name": "store3",
             "Host": "172.31.9.140",
             "Port": 6379,
-            "ArtificialLatencyMs": 40
+            "ArtificialLatencyInMs": 40
         },
         {
             "RegionType": "remote",
             "Name": "store4",
             "Host": "172.31.12.96",
             "Port": 6380,
-            "ArtificialLatencyMs": 100
+            "ArtificialLatencyInMs": 100
         }
     ]
 }

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	// create all backend storages
 	for _, store := range config.RKVConfig.Stores {
-		db, err := database.Factory(config.RKVConfig.StoreType, fmt.Sprintf("%s:%d", store.Host, store.Port))
+		db, err := database.Factory(config.RKVConfig.StoreType, &store)
 		if err != nil {
 			klog.Warningf("storage creation fails with $s: %v", store.Name, err)
 			continue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,11 +32,11 @@ type KVConfiguration struct {
 	Concurrent     bool
 }
 type KVStore struct {
-	RegionType          string
-	Name                string
-	Host                string
-	Port                int
-	ArtificialLatencyMs int
+	RegionType            string
+	Name                  string
+	Host                  string
+	Port                  int
+	ArtificialLatencyInMs int
 }
 
 func NewKVConfiguration(fileName string) (*KVConfiguration, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,10 +32,11 @@ type KVConfiguration struct {
 	Concurrent     bool
 }
 type KVStore struct {
-	RegionType string
-	Name       string
-	Host       string
-	Port       int
+	RegionType          string
+	Name                string
+	Host                string
+	Port                int
+	ArtificialLatencyMs int
 }
 
 func NewKVConfiguration(fileName string) (*KVConfiguration, error) {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -27,7 +27,7 @@ func Factory(databaseType string, store *config.KVStore) (Database, error) {
 		databaseUrl := fmt.Sprintf("%s:%d", store.Host, store.Port)
 		return NewMemDatabase(databaseUrl), nil
 	case "dummy+latency": // simulator database backend suitable for internal perf load test
-		return newLatencyDummyDatabase(time.Duration(store.ArtificialLatencyMs) * time.Millisecond), nil
+		return newLatencyDummyDatabase(time.Duration(store.ArtificialLatencyInMs) * time.Millisecond), nil
 	default:
 		return nil, &DatabaseNotImplementedError{databaseType}
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,5 +1,11 @@
 package database
 
+import (
+	"fmt"
+	"github.com/regionless-storage-service/pkg/config"
+	"time"
+)
+
 var (
 	// Storages keeps all backend storages indexed by name
 	Storages map[string]Database = make(map[string]Database)
@@ -12,12 +18,16 @@ type Database interface {
 	Close() error
 }
 
-func Factory(databaseType, databaseUrl string) (Database, error) {
+func Factory(databaseType string, store *config.KVStore) (Database, error) {
 	switch databaseType {
 	case "redis":
+		databaseUrl := fmt.Sprintf("%s:%d", store.Host, store.Port)
 		return createRedisDatabase(databaseUrl)
 	case "mem":
+		databaseUrl := fmt.Sprintf("%s:%d", store.Host, store.Port)
 		return NewMemDatabase(databaseUrl), nil
+	case "dummy+latency": // simulator database backend suitable for internal perf load test
+		return newLatencyDummyDatabase(time.Duration(store.ArtificialLatencyMs) * time.Millisecond), nil
 	default:
 		return nil, &DatabaseNotImplementedError{databaseType}
 	}

--- a/pkg/database/dymmydb.go
+++ b/pkg/database/dymmydb.go
@@ -1,0 +1,24 @@
+package database
+
+type dummyDatabase struct{}
+
+func (d dummyDatabase) Put(key, value string) (string, error) {
+	return "dummy put accepted", nil
+}
+
+func (d dummyDatabase) Get(key string) (string, error) {
+	// todo: to have more flexible way generating returns
+	return "dummy value for key " + key, nil
+}
+
+func (d dummyDatabase) Delete(key string) error {
+	return nil
+}
+
+func (d dummyDatabase) Close() error {
+	return nil
+}
+
+func newDummyDatabase() Database {
+	return dummyDatabase{}
+}

--- a/pkg/database/latencydb.go
+++ b/pkg/database/latencydb.go
@@ -1,0 +1,34 @@
+package database
+
+import "time"
+
+// latencyDatabase is decorator of adding specified latency to the underlying backend
+type latencyDatabase struct {
+	backend Database
+	latency time.Duration
+}
+
+func (l latencyDatabase) Put(key, value string) (string, error) {
+	time.Sleep(l.latency)
+	return l.backend.Put(key, value)
+}
+
+func (l latencyDatabase) Get(key string) (string, error) {
+	time.Sleep(l.latency)
+	return l.backend.Get(key)
+}
+
+func (l latencyDatabase) Delete(key string) error {
+	time.Sleep(l.latency)
+	return l.backend.Delete(key)
+}
+
+func (l latencyDatabase) Close() error {
+	// not to apply latency for close op
+	return l.backend.Close()
+}
+
+// newLatencyDummyDatabase returns a simulated database backend which is able to apply fixed latency to CRUD ops
+func newLatencyDummyDatabase(latency time.Duration) Database {
+	return &latencyDatabase{backend: newDummyDatabase(), latency: latency}
+}


### PR DESCRIPTION
This PR introduces a new back-end type "dummy+latency", which is a dummy database with tune-able latency. This type is targeted as simulator back-end suitable for internal go-ycsb perf test.

## How to use this new back-end
1. Here is sample config.json to enable 3 dummy+latency back-ends, each having different artificial latencies:
```json
{
    "ConsistentHash": "rendezvous",
    "BucketSize": 10,
    "ReplicaNum": 3,
    "StoreType": "dummy+latency",
    "Concurrent": true,
    "Stores": [
        {
            "RegionType": "local",
            "Name": "store1",
            "Host": "127.0.0.1",
            "Port": 6379,
            "ArtificialLatencyMs": 1
        },
        {
            "RegionType": "neighbor",
            "Name": "store3",
            "Host": "172.31.9.140",
            "Port": 6379,
            "ArtificialLatencyMs": 40
        },
        {
            "RegionType": "remote",
            "Name": "store4",
            "Host": "172.31.12.96",
            "Port": 6380,
            "ArtificialLatencyMs": 100
        }
    ]
}
``` 
2. start rkv (notice no need to prepare redis servers at all)
3. run curl to see basic insert/get k-v works (notice the value got back is not the original inserted)
```
$ curl -X POST http://127.0.0.1:8090/kv -d '{"key":"a","value":"113"}'
The key value pair (a,113) has been saved as revision 1 at store1,store3,store4
$ curl http://127.0.0.1:8090/kv?key=a
The value is dummy value for key 1 with the revision 1

```
5. run go-ycsb, with threadcount 4
```
$ ./bin/go-ycsb load rkv -P workloads/workloada
***************** properties *****************
"updateproportion"="0.5"
"requestdistribution"="uniform"
"recordcount"="1000"
"scanproportion"="0"
"insertproportion"="0"
"operationcount"="1000"
"workload"="core"
"threadcount"="4"
"readallfields"="true"
"readproportion"="0.5"
"dotransactions"="false"
**********************************************
INSERT - Takes(s): 9.9, Count: 338, OPS: 34.1, Avg(us): 103404, Min(us): 101376, Max(us): 104895, 99th(us): 104767, 99.9th(us): 104895, 99.99th(us): 104895
INSERT - Takes(s): 19.9, Count: 695, OPS: 34.9, Avg(us): 103442, Min(us): 101184, Max(us): 105279, 99th(us): 105151, 99.9th(us): 105279, 99.99th(us): 105279
Run finished, takes 25.944365359s
INSERT - Takes(s): 25.8, Count: 909, OPS: 35.2, Avg(us): 103501, Min(us): 101184, Max(us): 105215, 99th(us): 105087, 99.9th(us): 105215, 99.99th(us): 105215

$ ./bin/go-ycsb run rkv -P workloads/workloada
***************** properties *****************
"insertproportion"="0"
"workload"="core"
"requestdistribution"="uniform"
"threadcount"="4"
"operationcount"="1000"
"readallfields"="true"
"updateproportion"="0.5"
"dotransactions"="true"
"recordcount"="1000"
"readproportion"="0.5"
"scanproportion"="0"
**********************************************
READ   - Takes(s): 9.9, Count: 183, OPS: 18.5, Avg(us): 102696, Min(us): 101184, Max(us): 107263, 99th(us): 104319, 99.9th(us): 107263, 99.99th(us): 107263
UPDATE - Takes(s): 9.9, Count: 185, OPS: 18.7, Avg(us): 102693, Min(us): 101440, Max(us): 103807, 99th(us): 103743, 99.9th(us): 103807, 99.99th(us): 103807
READ   - Takes(s): 19.9, Count: 366, OPS: 18.4, Avg(us): 102858, Min(us): 101184, Max(us): 103743, 99th(us): 103615, 99.9th(us): 103743, 99.99th(us): 103743
UPDATE - Takes(s): 19.9, Count: 365, OPS: 18.3, Avg(us): 102681, Min(us): 101440, Max(us): 103999, 99th(us): 103871, 99.9th(us): 103999, 99.99th(us): 103999
Run finished, takes 25.6878228s
READ   - Takes(s): 25.6, Count: 470, OPS: 18.4, Avg(us): 102565, Min(us): 101184, Max(us): 103679, 99th(us): 103615, 99.9th(us): 103679, 99.99th(us): 103679
UPDATE - Takes(s): 25.6, Count: 470, OPS: 18.4, Avg(us): 102888, Min(us): 101440, Max(us): 103935, 99th(us): 103743, 99.9th(us): 103935, 99.99th(us): 103935
```