### PR TITLE
bug fix: stale rev still updates

### DIFF
--- a/pkg/index/key_index.go
+++ b/pkg/index/key_index.go
@@ -90,9 +90,9 @@ func (ki *keyIndex) put(main int64, sub int64, nodes []string) {
 	} else {
 		g.revs = append(g.revs, rev)
 	}
-	g.ver++
 
 	if rev.GreaterThan(ki.modified) {
+		g.ver++
 		ki.modified = rev
 	}
 }

--- a/pkg/index/key_index.go
+++ b/pkg/index/key_index.go
@@ -60,7 +60,6 @@ type keyIndex struct {
 	generations []generation
 }
 
-// todo: return error instead to panic
 // put puts a Revision to the keyIndex.
 func (ki *keyIndex) put(main int64, sub int64, nodes []string) {
 	rev := Revision{main: main, sub: sub, nodes: nodes}
@@ -274,7 +273,7 @@ func (g *generation) walk(f func(rev Revision) bool) int {
 }
 
 func (g *generation) String() string {
-	return fmt.Sprintf("g: created[%d] ver[%d], revs %#v\n", g.created, g.ver, g.revs)
+	return fmt.Sprintf("g: created[%s] ver[%d], revs %#v\n", g.created, g.ver, g.revs)
 }
 
 func (a generation) equal(b generation) bool {

--- a/pkg/index/key_index_test.go
+++ b/pkg/index/key_index_test.go
@@ -1,0 +1,83 @@
+package index
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPut(t *testing.T) {
+	tcs := []struct {
+		name                string
+		index               keyIndex
+		revToPut            Revision
+		expectedModified    Revision
+		expectedGenerations []generation
+	}{
+		{
+			name: "put newer rev",
+			index: keyIndex{
+				key:      []byte("testkey"),
+				modified: Revision{main: 99, sub: 0, nodes: []string{"node2"}},
+				generations: []generation{{
+					ver:     2,
+					created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+					revs: []Revision{
+						{main: 98, sub: 0, nodes: []string{"node1"}},
+						{main: 99, sub: 0, nodes: []string{"node2"}},
+					},
+				}}},
+			revToPut:         Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+			expectedModified: Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+			expectedGenerations: []generation{{
+				ver:     3,
+				created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+				revs: []Revision{
+					{main: 98, sub: 0, nodes: []string{"node1"}},
+					{main: 99, sub: 0, nodes: []string{"node2"}},
+					{main: 100, sub: 0, nodes: []string{"node3"}},
+				},
+			},
+			},
+		},
+		{
+			name: "put stale rev",
+			index: keyIndex{
+				key:      []byte("testkey"),
+				modified: Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+				generations: []generation{{
+					ver:     2,
+					created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+					revs: []Revision{
+						{main: 98, sub: 0, nodes: []string{"node1"}},
+						{main: 100, sub: 0, nodes: []string{"node3"}},
+					},
+				}}},
+			revToPut:         Revision{main: 99, sub: 0, nodes: []string{"node2"}},
+			expectedModified: Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+			expectedGenerations: []generation{{
+				ver:     2,
+				created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+				revs: []Revision{
+					{main: 98, sub: 0, nodes: []string{"node1"}},
+					{main: 99, sub: 0, nodes: []string{"node2"}},
+					{main: 100, sub: 0, nodes: []string{"node3"}},
+				},
+			},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.index.put(tc.revToPut.main, tc.revToPut.sub, tc.revToPut.GetNodes())
+
+			if !reflect.DeepEqual(tc.index.modified, tc.expectedModified) {
+				t.Errorf("extecped modified rev %v, got %v", tc.expectedModified, tc.index.modified)
+			}
+
+			if !reflect.DeepEqual(tc.expectedGenerations, tc.index.generations) {
+				t.Errorf("extecped resultant generations %v, got %v", tc.expectedGenerations, tc.index.generations)
+			}
+		})
+	}
+}


### PR DESCRIPTION
this PR fixes #58 

stale updates are still allowed - not treated as failure; but the latest modified and generation version intact (not to be affected), so that getting the latest value would always return the newest rev.

it comes with a unit test to ensure such behavior.