### PR TITLE
Changes to load nodes in local zones and remote nodes based on connection latencies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,3 +25,5 @@ jobs:
         go get github.com/google/btree
     - name: Run build
       run: make build
+    - name: Run unit tests
+      run: go test ./...

--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -2,13 +2,14 @@
     "ConsistentHash": "rendezvous",
     "BucketSize": 10,
     "ReplicaNum": {
+        "//" : "The number of local replica from the ones whose latency is fewer than RemoteStoreLatencyThresholdInMilliSec", 
         "Local": 2,
+        "//" : "The number of remote replica from the ones whose latency is more than or equals to RemoteStoreLatencyThresholdInMilliSec", 
         "Remote": 1
     },
     "StoreType": "mem",
     "Concurrent": true,
-    "//" : "The threshold is to check if a store is located in a remote datacenter. It is the latency in millis seconds to set up connection", 
-    "RemoteStoreLatencyThreshold": 100,
+    "RemoteStoreLatencyThresholdInMilliSec": 100,
     "Stores": [
         {
             "Region": "us-west-1",

--- a/cmd/http/config.json
+++ b/cmd/http/config.json
@@ -1,26 +1,34 @@
 {
     "ConsistentHash": "rendezvous",
     "BucketSize": 10,
-    "ReplicaNum": 3,
+    "ReplicaNum": {
+        "Local": 2,
+        "Remote": 1
+    },
     "StoreType": "mem",
     "Concurrent": true,
+    "//" : "The threshold is to check if a store is located in a remote datacenter. It is the latency in millis seconds to set up connection", 
+    "RemoteStoreLatencyThreshold": 100,
     "Stores": [
         {
-            "RegionType": "local",
+            "Region": "us-west-1",
+            "AvailabilityZone": "us-west-1b",
             "Name": "store1",
             "Host": "127.0.0.1",
             "Port": 6379,
             "ArtificialLatencyInMs": 1
         },
         {
-            "RegionType": "neighbor",
+            "Region": "us-west-2",
+            "AvailabilityZone": "us-west-2a",
             "Name": "store3",
             "Host": "172.31.9.140",
             "Port": 6379,
             "ArtificialLatencyInMs": 40
         },
         {
-            "RegionType": "remote",
+            "Region": "us-west-2",
+            "AvailabilityZone": "us-west-2b",
             "Name": "store4",
             "Host": "172.31.12.96",
             "Port": 6380,

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -76,7 +76,7 @@ type KeyValueHandler struct {
 
 func NewKeyValueHandler(conf *config.KVConfiguration) *KeyValueHandler {
 
-	localStores, remoteStores, err := conf.GetReplications(conf.RemoteStoreLatencyThreshold)
+	localStores, remoteStores, err := conf.GetReplications(conf.RemoteStoreLatencyThresholdInMilliSec)
 	if err != nil {
 		panic(fmt.Errorf("error in get replications: %v", err))
 	}
@@ -215,7 +215,7 @@ func (handler *KeyValueHandler) createKV(w http.ResponseWriter, r *http.Request)
 
 	rev := revision.GetGlobalIncreasingRevision()
 	newRev := index.NewRevision(int64(rev), 0, nil)
-	lns, rns, err := handler.hm.GetLocalAndRemoteNodes(handler.getPrimaryRevBytesWithBucket(newRev))
+	localNodes, remoteNodes, err := handler.hm.GetLocalAndRemoteNodes(handler.getPrimaryRevBytesWithBucket(newRev))
 	if err != nil {
 		klog.Errorf("failed to get all the nodes: %v", err)
 		return "", err
@@ -223,12 +223,10 @@ func (handler *KeyValueHandler) createKV(w http.ResponseWriter, r *http.Request)
 
 	nodes := []string{}
 
-	for _, ln := range lns {
-		fmt.Printf("The local string is %s\n", ln.String())
+	for _, ln := range localNodes {
 		nodes = append(nodes, ln.String())
 	}
-	for _, rn := range rns {
-		fmt.Printf("The remote string is %s\n", rn.String())
+	for _, rn := range remoteNodes {
 		nodes = append(nodes, rn.String())
 	}
 	newRev.SetNodes(nodes)

--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -56,7 +56,7 @@ func main() {
 	for _, store := range config.RKVConfig.Stores {
 		db, err := database.Factory(config.RKVConfig.StoreType, &store)
 		if err != nil {
-			klog.Warningf("storage creation fails with $s: %v", store.Name, err)
+			klog.Warningf("storage creation fails with %s: %v", store.Name, err)
 			continue
 		}
 		database.Storages[store.Name] = db
@@ -75,8 +75,7 @@ type KeyValueHandler struct {
 }
 
 func NewKeyValueHandler(conf *config.KVConfiguration) *KeyValueHandler {
-
-	localStores, remoteStores, err := conf.GetReplications(conf.RemoteStoreLatencyThresholdInMilliSec)
+	localStores, remoteStores, err := conf.GetReplications()
 	if err != nil {
 		panic(fmt.Errorf("error in get replications: %v", err))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,13 +26,13 @@ var (
 )
 
 type KVConfiguration struct {
-	ConsistentHash              string
-	StoreType                   string
-	Stores                      []KVStore
-	BucketSize                  int64
-	ReplicaNum                  ReplicaNum
-	Concurrent                  bool
-	RemoteStoreLatencyThreshold int64
+	ConsistentHash                        string
+	StoreType                             string
+	Stores                                []KVStore
+	BucketSize                            int64
+	ReplicaNum                            ReplicaNum
+	Concurrent                            bool
+	RemoteStoreLatencyThresholdInMilliSec int64
 }
 
 type ReplicaNum struct {
@@ -87,7 +87,6 @@ func (c *KVConfiguration) GetReplications(remoteStoreLatencyThreshold int64) (ma
 			}
 		}
 	}
-	fmt.Printf("The local is %v and the remote is %v", localStores, remoteStores)
 	return localStores, remoteStores, nil
 }
 

--- a/pkg/constants/availability_zone.go
+++ b/pkg/constants/availability_zone.go
@@ -1,0 +1,29 @@
+package constants
+
+type AvailabilityZone string
+
+func (az AvailabilityZone) Name() string {
+	return string(az)
+}
+
+const (
+	US_EAST_1A AvailabilityZone = "us-east-1a"
+	US_EAST_1B AvailabilityZone = "us-east-1b"
+	US_EAST_1C AvailabilityZone = "us-east-1c"
+	US_EAST_1D AvailabilityZone = "us-east-1d"
+	US_EAST_1E AvailabilityZone = "us-east-1e"
+
+	US_EAST_2A AvailabilityZone = "us-east-2a"
+	US_EAST_2B AvailabilityZone = "us-east-2b"
+	US_EAST_2C AvailabilityZone = "us-east-2c"
+
+	US_WEST_1A AvailabilityZone = "us-west-1a"
+	US_WEST_1B AvailabilityZone = "us-west-1b"
+	US_WEST_1C AvailabilityZone = "us-west-1c"
+
+	US_WEST_2A AvailabilityZone = "us-west-2a"
+	US_WEST_2B AvailabilityZone = "us-west-2b"
+	US_WEST_2C AvailabilityZone = "us-west-2c"
+
+	DEFAULT_AZ AvailabilityZone = US_WEST_1A
+)

--- a/pkg/constants/region.go
+++ b/pkg/constants/region.go
@@ -1,0 +1,15 @@
+package constants
+
+type Region string
+
+func (r Region) Name() string {
+	return string(r)
+}
+
+const (
+	US_EAST_1      Region = "us-east-1"
+	US_EAST_2      Region = "us-east-2"
+	US_WEST_1      Region = "us-west-1"
+	US_WEST_2      Region = "us-west-2"
+	DEFAULT_REGION Region = US_WEST_1
+)

--- a/pkg/constants/store.go
+++ b/pkg/constants/store.go
@@ -1,0 +1,13 @@
+package constants
+
+type StoreType string
+
+func (r StoreType) Name() string {
+	return string(r)
+}
+
+const (
+	Memory       StoreType = "mem"
+	Redis        StoreType = "redis"
+	DummyLatency StoreType = "dummy+latency"
+)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2,8 +2,10 @@ package database
 
 import (
 	"fmt"
-	"github.com/regionless-storage-service/pkg/config"
 	"time"
+
+	"github.com/regionless-storage-service/pkg/config"
+	"github.com/regionless-storage-service/pkg/constants"
 )
 
 var (
@@ -18,17 +20,17 @@ type Database interface {
 	Close() error
 }
 
-func Factory(databaseType string, store *config.KVStore) (Database, error) {
+func Factory(databaseType constants.StoreType, store *config.KVStore) (Database, error) {
 	switch databaseType {
-	case "redis":
+	case constants.Redis:
 		databaseUrl := fmt.Sprintf("%s:%d", store.Host, store.Port)
 		return createRedisDatabase(databaseUrl)
-	case "mem":
+	case constants.Memory:
 		databaseUrl := fmt.Sprintf("%s:%d", store.Host, store.Port)
 		return NewMemDatabase(databaseUrl), nil
-	case "dummy+latency": // simulator database backend suitable for internal perf load test
+	case constants.DummyLatency: // simulator database backend suitable for internal perf load test
 		return newLatencyDummyDatabase(time.Duration(store.ArtificialLatencyInMs) * time.Millisecond), nil
 	default:
-		return nil, &DatabaseNotImplementedError{databaseType}
+		return nil, &DatabaseNotImplementedError{databaseType.Name()}
 	}
 }

--- a/pkg/index/key_index.go
+++ b/pkg/index/key_index.go
@@ -255,7 +255,7 @@ func (g *generation) walk(f func(rev Revision) bool) int {
 }
 
 func (g *generation) String() string {
-	return fmt.Sprintf("g: created[%d] ver[%d], revs %#v\n", g.created, g.ver, g.revs)
+	return fmt.Sprintf("g: created[%s] ver[%d], revs %#v\n", g.created, g.ver, g.revs)
 }
 
 func (a generation) equal(b generation) bool {

--- a/pkg/partition/consistent/hashing.go
+++ b/pkg/partition/consistent/hashing.go
@@ -1,5 +1,12 @@
 package consistent
 
+import (
+	"fmt"
+
+	"github.com/cespare/xxhash"
+	"github.com/regionless-storage-service/pkg/constants"
+)
+
 type Hasher interface {
 	Hash([]byte) uint64
 }
@@ -11,4 +18,73 @@ type Node interface {
 type ConsistentHashing interface {
 	AddNode(node Node)
 	LocateKey(key []byte) Node
+	LocateNodes(key []byte, count int) []Node
+}
+
+type rkvNode string
+
+func (tn rkvNode) String() string {
+	return string(tn)
+}
+
+type rkvHash struct{}
+
+func (th rkvHash) Hash(key []byte) uint64 {
+	return xxhash.Sum64(key)
+}
+
+type KV struct {
+	key, value string
+}
+
+type HashingWithAzandRemote struct {
+	AzHashing    ConsistentHashing
+	LocalHashing map[constants.AvailabilityZone]ConsistentHashing
+	RemoteHasing ConsistentHashing
+	LocalCount   int
+	RemoteCount  int
+}
+
+func NewHashingWithLocalAndRemote(localStores map[constants.AvailabilityZone][]string, localCount int, remoteStores []string, remoteCount int) HashingWithAzandRemote {
+	hasher := rkvHash{}
+	azRing := NewRendezvous(nil, hasher)
+	localRing := make(map[constants.AvailabilityZone]ConsistentHashing)
+	for az, stores := range localStores {
+		azRing.AddNode(rkvNode(az))
+		if _, found := localRing[az]; !found {
+			localRing[az] = NewRendezvous(nil, hasher)
+		}
+		for _, store := range stores {
+			localRing[az].AddNode(rkvNode(store))
+		}
+	}
+	remoteRing := NewRendezvous(nil, hasher)
+	for _, store := range remoteStores {
+		remoteRing.AddNode(rkvNode(store))
+	}
+	return HashingWithAzandRemote{AzHashing: azRing, LocalHashing: localRing, RemoteHasing: remoteRing, LocalCount: localCount, RemoteCount: remoteCount}
+}
+
+func (h HashingWithAzandRemote) GetLocalAndRemoteNodes(key []byte) ([]rkvNode, []rkvNode, error) {
+	localNodes := []rkvNode{}
+	azs := h.AzHashing.LocateNodes(key, h.LocalCount)
+	if len(azs) != h.LocalCount {
+		return nil, nil, fmt.Errorf("failed to get %d zones. The return number is %d", h.LocalCount, len(azs))
+	}
+	for _, az := range azs {
+		lnodes := h.LocalHashing[constants.AvailabilityZone(az.String())].LocateNodes(key, 1)
+		if len(lnodes) != 1 {
+			return nil, nil, fmt.Errorf("failed to get 1 local node. The return number is %d", len(lnodes))
+		}
+		localNodes = append(localNodes, rkvNode(lnodes[0].String()))
+	}
+	remoteNodes := []rkvNode{}
+	rnodes := h.RemoteHasing.LocateNodes(key, h.RemoteCount)
+	if len(rnodes) != h.RemoteCount {
+		return nil, nil, fmt.Errorf("failed to get %d remote nodes. The return number is %d", h.RemoteCount, len(rnodes))
+	}
+	for _, rn := range rnodes {
+		remoteNodes = append(remoteNodes, rkvNode(rn.String()))
+	}
+	return localNodes, remoteNodes, nil
 }

--- a/pkg/partition/consistent/rendezvous.go
+++ b/pkg/partition/consistent/rendezvous.go
@@ -64,3 +64,26 @@ func xorshiftMult64(x uint64) uint64 {
 	x ^= x >> 27 // c
 	return x * 2685821657736338717
 }
+
+func (r *Rendezvous) LocateNodes(key []byte, count int) []Node {
+	if len(r.nodes) < count {
+		return nil
+	}
+
+	khash := r.hasher.Hash(key)
+
+	var midx int
+	var mhash = xorshiftMult64(khash ^ r.nhash[0])
+
+	for i, nhash := range r.nhash[1:] {
+		if h := xorshiftMult64(khash ^ nhash); h > mhash {
+			midx = i + 1
+			mhash = h
+		}
+	}
+	res := make([]Node, count)
+	for i := 0; i < count; i++ {
+		res[i] = r.nstr[(midx+i)%len(r.nodes)]
+	}
+	return res
+}

--- a/pkg/partition/consistent/ring.go
+++ b/pkg/partition/consistent/ring.go
@@ -80,3 +80,25 @@ func (rh *RingHashing) GetNodes() []Node {
 	}
 	return nodes
 }
+
+func (rh *RingHashing) LocateNodes(key []byte, count int) []Node {
+	if len(rh.nodes) < count {
+		return nil
+	}
+	partID := rh.FindPartitionID(key)
+	rh.mu.RLock()
+	defer rh.mu.RUnlock()
+	if partID < 0 {
+		return nil
+	}
+	res := make([]Node, count)
+	for i := 0; i < count; i++ {
+		node, ok := rh.ring[rh.sortedSet[(partID+i)%len(rh.nodes)]]
+		if !ok {
+			return nil
+		}
+		res[i] = *node
+	}
+
+	return res
+}

--- a/pkg/piping/chain_piping_manager.go
+++ b/pkg/piping/chain_piping_manager.go
@@ -7,18 +7,19 @@ import (
 	"github.com/regionless-storage-service/pkg/config"
 	"github.com/regionless-storage-service/pkg/consistent"
 	"github.com/regionless-storage-service/pkg/consistent/chain"
+	"github.com/regionless-storage-service/pkg/constants"
 	"github.com/regionless-storage-service/pkg/index"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 )
 
 type ChainPiping struct {
-	databaseType string
+	databaseType constants.StoreType
 	consistency  consistent.CONSISTENCY
 	concurrent   bool
 }
 
-func NewChainPiping(databaseType string, consistency consistent.CONSISTENCY, concurrent bool) *ChainPiping {
+func NewChainPiping(databaseType constants.StoreType, consistency consistent.CONSISTENCY, concurrent bool) *ChainPiping {
 	return &ChainPiping{databaseType: databaseType, consistency: consistency, concurrent: concurrent}
 }
 

--- a/test/consistent/chain/chain_test.go
+++ b/test/consistent/chain/chain_test.go
@@ -68,7 +68,7 @@ func TestChainWriteSEQUENTIAL(t *testing.T) {
 	if _, err := chain.GetTail().Read(context.TODO(), "k1"); err == nil {
 		t.Fatalf("tail failed is supposed not to find the key")
 	}
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	if v1, err := chain.GetTail().Read(context.TODO(), "k1"); err != nil {
 		t.Fatalf("tail failed to read  with error %v", err)
 	} else if v1 != "v1" {

--- a/test/partition/consistent/hashing_test.go
+++ b/test/partition/consistent/hashing_test.go
@@ -1,0 +1,88 @@
+package consistent
+
+import (
+	"testing"
+
+	"github.com/regionless-storage-service/pkg/constants"
+	"github.com/regionless-storage-service/pkg/partition/consistent"
+)
+
+func TestNewHashingWithLocalAndRemote(t *testing.T) {
+	localStores := map[constants.AvailabilityZone][]string{
+		constants.US_EAST_1A: {"1.1.3.4:1000", "1.2.3.4:1000"},
+		constants.US_EAST_2A: {"3.2.3.4:2000", "3.1.3.4:2000", "3.9.3.4:2000"},
+		constants.US_WEST_1A: {"6.2.3.4:3000", "6.2.3.4:3000"},
+	}
+
+	RemoteStores := []string{"9.2.3.4:1000", "9.2.3.4:2000"}
+
+	h := consistent.NewHashingWithLocalAndRemote(localStores, 2, RemoteStores, 1)
+	l, r, _ := h.GetLocalAndRemoteNodes([]byte("1"))
+	if l == nil {
+		t.Fatalf("Local nodes shouldn't be nil: %v", l)
+	}
+	if r == nil {
+		t.Fatalf("Remote nodes shouldn't be nil: %v", r)
+	}
+	if len(l) != 2 {
+		t.Fatalf("Local nodes shouldn't be %d", len(l))
+	}
+	if len(r) != 1 {
+		t.Fatalf("Remote nodes shouldn't be %d", len(r))
+	}
+	lnMap := make(map[string]bool)
+	for _, ln := range l {
+		lk := ln.String()[0:1]
+		if _, found := lnMap[lk]; found {
+			t.Fatalf("Same az selected %v", ln)
+		}
+		lnMap[lk] = true
+	}
+	for _, rn := range r {
+		rk := rn.String()[0:1]
+		if rk != "9" {
+			t.Fatalf("Unexpected az selected %v", rn)
+		}
+	}
+}
+
+func TestOneLocalStore(t *testing.T) {
+	localStores := map[constants.AvailabilityZone][]string{
+		constants.US_EAST_1A: {"1.1.3.4:1000", "1.2.3.4:1000"},
+		constants.US_EAST_2A: {"3.2.3.4:2000", "3.1.3.4:2000", "3.9.3.4:2000"},
+		constants.US_WEST_1A: {"6.2.3.4:3000", "6.2.3.4:3000"},
+	}
+
+	RemoteStores := []string{"9.2.3.4:1000", "9.2.3.4:2000"}
+
+	h := consistent.NewHashingWithLocalAndRemote(localStores, 1, RemoteStores, 0)
+	l, r, _ := h.GetLocalAndRemoteNodes([]byte("1"))
+	if l == nil {
+		t.Fatalf("Local nodes shouldn't be nil: %v", l)
+	}
+	if r == nil {
+		t.Fatalf("Remote nodes shouldn't be nil: %v", r)
+	}
+	if len(l) != 1 {
+		t.Fatalf("Local nodes shouldn't be %d", len(l))
+	}
+	if len(r) != 0 {
+		t.Fatalf("Remote nodes shouldn't be %d", len(r))
+	}
+}
+
+func TestZeroRemoteStore(t *testing.T) {
+	localStores := map[constants.AvailabilityZone][]string{
+		constants.US_EAST_1A: {"1.1.3.4:1000", "1.2.3.4:1000"},
+		constants.US_EAST_2A: {"3.2.3.4:2000", "3.1.3.4:2000", "3.9.3.4:2000"},
+		constants.US_WEST_1A: {"6.2.3.4:3000", "6.2.3.4:3000"},
+	}
+
+	RemoteStores := []string{}
+
+	h := consistent.NewHashingWithLocalAndRemote(localStores, 1, RemoteStores, 1)
+	_, _, err := h.GetLocalAndRemoteNodes([]byte("1"))
+	if err == nil {
+		t.Fatalf("err is expected")
+	}
+}

--- a/test/partition/consistent/rendezvous_test.go
+++ b/test/partition/consistent/rendezvous_test.go
@@ -47,3 +47,33 @@ func TestRendezvousLocateKey(t *testing.T) {
 		t.Fatalf("This shouldn't be nil: %v", res)
 	}
 }
+
+func TestRendezvousLocateNodes(t *testing.T) {
+	rdz := consistent.NewRendezvous(nil, testHash{})
+	key := []byte("TestKey")
+	res := rdz.LocateNodes(key, 1)
+	if res != nil {
+		t.Fatalf("This should be nil: %v", res)
+	}
+	nodes := make(map[string]struct{})
+	for i := 0; i < 8; i++ {
+		node := testNode(fmt.Sprintf("127.0.0.1:808%d", i))
+		nodes[node.String()] = struct{}{}
+		rdz.AddNode(node)
+	}
+	res = rdz.LocateNodes(key, 1)
+	if res == nil {
+		t.Fatalf("This shouldn't be nil: %v", res)
+	}
+	if len(res) != 1 {
+		t.Fatalf("This shouldn't be %d", len(res))
+	}
+	res = rdz.LocateNodes(key, 9)
+	if res != nil {
+		t.Fatalf("This should be nil: %v", res)
+	}
+	res = rdz.LocateNodes(key, 3)
+	if len(res) != 3 {
+		t.Fatalf("This shouldn't be %d", len(res))
+	}
+}

--- a/test/partition/consistent/ring_test.go
+++ b/test/partition/consistent/ring_test.go
@@ -60,3 +60,33 @@ func TestLocateKey(t *testing.T) {
 		t.Fatalf("This shouldn't be nil: %v", res)
 	}
 }
+
+func TestRingLocateNodes(t *testing.T) {
+	rdz := consistent.NewRingHashing(testHash{})
+	key := []byte("TestKey")
+	res := rdz.LocateNodes(key, 1)
+	if res != nil {
+		t.Fatalf("This should be nil: %v", res)
+	}
+	nodes := make(map[string]struct{})
+	for i := 0; i < 8; i++ {
+		node := testNode(fmt.Sprintf("127.0.0.1:808%d", i))
+		nodes[node.String()] = struct{}{}
+		rdz.AddNode(node)
+	}
+	res = rdz.LocateNodes(key, 1)
+	if res == nil {
+		t.Fatalf("This shouldn't be nil: %v", res)
+	}
+	if len(res) != 1 {
+		t.Fatalf("This shouldn't be %d", len(res))
+	}
+	res = rdz.LocateNodes(key, 9)
+	if res != nil {
+		t.Fatalf("This should be nil: %v", res)
+	}
+	res = rdz.LocateNodes(key, 3)
+	if len(res) != 3 {
+		t.Fatalf("This shouldn't be %d", len(res))
+	}
+}

--- a/test/piping/chain_piping_manager_test.go
+++ b/test/piping/chain_piping_manager_test.go
@@ -12,6 +12,7 @@ import (
 func TestWriteLINEARIZABLE(t *testing.T) {
 	cp := piping.NewChainPiping("mem", consistent.LINEARIZABLE, false)
 	rev := index.NewRevision(1, 0, []string{"0.0.0.0:0", "1.1.1.1:1", "2.2.2.2:2", "3.3.3.3:3"})
+
 	if err := cp.Write(context.TODO(), rev, "v"); err != nil {
 		t.Fatalf("fail to write with the error %v", err)
 	}


### PR DESCRIPTION
1. Added region and availability zones to data stores

2. Added latency threshold to check if the data store is a remote one
For example, if a datastore connection latency is more than or equals to 100ms, it will be a remote store. Otherwise it is a local store

3. Updated replica numbers to local and remote ones
Based on the 2, we will choose local replica number stores for synchronization writes. For remote stores, we will chose remote replica number stores for asynchronization writes.

4. Updated the consistent hashing to fetch availability zones first and then the nodes in the availability zones for local stores.

5. Added unit test step to workflow