### PR TITLE
bug fix: rev nodes indentify back-ends by name

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -253,6 +253,7 @@ func (handler *KeyValueHandler) createKV(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
+			return "", fmt.Errorf("system backend failed to write data: %v", err)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ func NewKVConfiguration(fileName string) (*KVConfiguration, error) {
 }
 
 // Returns local stores grouping by AvailabilityZone and remote stores in array
+// returned items identifing backend stores by name, NOT by hostname:port - backend may be other than redis type
 func (c *KVConfiguration) GetReplications() (map[constants.AvailabilityZone][]string, []string, error) {
 	localStores := make(map[constants.AvailabilityZone][]string)
 	remoteStores := make([]string, 0)
@@ -88,9 +89,9 @@ func (c *KVConfiguration) GetReplications() (map[constants.AvailabilityZone][]st
 				locals := make([]string, 0)
 				localStores[store.AvailabilityZone] = locals
 			}
-			localStores[store.AvailabilityZone] = append(localStores[store.AvailabilityZone], target)
+			localStores[store.AvailabilityZone] = append(localStores[store.AvailabilityZone], store.Name)
 		} else {
-			remoteStores = append(remoteStores, target)
+			remoteStores = append(remoteStores, store.Name)
 		}
 	}
 	return localStores, remoteStores, nil

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -96,7 +96,7 @@ func TestLocalStores(t *testing.T) {
 			t.Fatalf("The local availiblity zone %s is not expected", az)
 		}
 		for _, localNode := range azNodes {
-			if localNode[0:7] != "127.0.0" {
+			if localNode[0:9] != "us-east-1" {
 				t.Fatalf("The local node %s is not expected", localNode)
 			}
 		}
@@ -188,7 +188,7 @@ func TestRemoteStores(t *testing.T) {
 		t.Fatalf("The remote store number is %d", len(remoteNodes))
 	}
 	for _, remoteNode := range remoteNodes {
-		if remoteNode[0:11] != "172.31.9.14" {
+		if remoteNode[0:9] != "us-east-2" {
 			t.Fatalf("The remote node %s is not expected", remoteNode)
 		}
 	}


### PR DESCRIPTION
This PR fixes bug #67 

The root cause of this bug is host-ip:port is used to identify back-end nodes in revision node replicas. However, system maintains a lookup table of databases by name only (as mem/dummy have no ip add nor port). The fix is trivial - when calculating identifiers of nodes, use name not ip:port.