### PR TITLE
retrieve prepared simulated backend if exists so as to observe the latency setting

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -44,6 +44,9 @@ func FactoryWithNameAndLatency(databaseType constants.StoreType, name string, la
 	case constants.Memory:
 		return NewMemDatabase(name), nil
 	case constants.DummyLatency: // simulator database backend suitable for internal perf load test
+		if db, ok := Storages[name]; ok {
+			return db, nil
+		}
 		return newLatencyDummyDatabase(latency), nil
 	default:
 		return nil, &DatabaseNotImplementedError{databaseType.Name()}


### PR DESCRIPTION
This PR is relatively small - it retrieves dummy-latency backend databases by name, in case thy are lept in database storages that is initialized when application starts up.

Current code creates dummy+latency back-end with 0 latency when assembling piping. This 0 latency defects the purpose of artificial latency setting.  This PR ensures the backend returned to have expected artificial latency setting.

go-ycsb verifies that this fix bring out the anticipated OPS (40 ms synchronous writes, about 23 OPS)
```
INSERT - Takes(s): 10.0, Count: 231, OPS: 23.2, Avg(us): 43058, Min(us): 41824, Max(us): 44927, 99th(us): 44511, 99.9th(us): 44927, 99.99th(us): 44927
INSERT - Takes(s): 20.0, Count: 463, OPS: 23.2, Avg(us): 43022, Min(us): 41536, Max(us): 46399, 99th(us): 44511, 99.9th(us): 46399, 99.99th(us): 46399
```