### PR TITLE
Fixed the issue that redis connections in the pool close automatically

### DIFF
--- a/pkg/constants/store.go
+++ b/pkg/constants/store.go
@@ -15,6 +15,6 @@ const (
 )
 
 const (
-	RetryCount                  int           = 5
-	RetryIntervalInMilliseconds time.Duration = 10 * time.Millisecond
+	RedisRetryCount    int           = 5
+	RedisRetryInterval time.Duration = 10 * time.Millisecond
 )

--- a/pkg/constants/store.go
+++ b/pkg/constants/store.go
@@ -1,5 +1,7 @@
 package constants
 
+import "time"
+
 type StoreType string
 
 func (r StoreType) Name() string {
@@ -10,4 +12,9 @@ const (
 	Memory       StoreType = "mem"
 	Redis        StoreType = "redis"
 	DummyLatency StoreType = "dummy+latency"
+)
+
+const (
+	RetryCount                  int           = 5
+	RetryIntervalInMilliseconds time.Duration = 10 * time.Millisecond
 )

--- a/pkg/database/redis.go
+++ b/pkg/database/redis.go
@@ -34,13 +34,12 @@ func initPool(host string, port int) (string, *redis.Pool) {
 		Dial: func() (redis.Conn, error) {
 			conn, err := redis.Dial("tcp", url)
 			for retries := 0; err != nil && retries < 5; retries++ {
+				log.Printf("ERROR: failed to init the redis %s connection with error %v after %d times\n", url, err, retries+1)
 				time.Sleep((10 << retries) * time.Millisecond)
 				if conn, err = redis.Dial("tcp", url); err == nil {
 					if _, err = conn.Do("PING"); err != nil {
-						log.Printf("ERROR: fail to ping redis %s: %v after %d retries\n", url, err, retries+1)
+						log.Printf("ERROR: failed to ping redis %s: %v after %d retries\n", url, err, retries+1)
 					}
-				} else {
-					log.Printf("ERROR: fail init redis: %v after %d retries\n", err, retries+1)
 				}
 			}
 			return conn, err

--- a/pkg/database/redis.go
+++ b/pkg/database/redis.go
@@ -34,10 +34,9 @@ func initPool(host string, port int) (string, *redis.Pool) {
 		MaxActive: 12000,
 		Dial: func() (redis.Conn, error) {
 			conn, err := redis.Dial("tcp", url)
-			for retries := 0; err != nil && retries < constants.RetryCount; retries++ {
+			for retries := 0; err != nil && retries < constants.RedisRetryCount; retries++ {
 				log.Printf("ERROR: failed to init the redis %s connection with error %v after %d times\n", url, err, retries+1)
-				interval := constants.RetryIntervalInMilliseconds << retries
-				time.Sleep(interval * time.Millisecond)
+				time.Sleep(constants.RedisRetryInterval << retries)
 				if conn, err = redis.Dial("tcp", url); err == nil {
 					if _, err = conn.Do("PING"); err != nil {
 						log.Printf("ERROR: failed to ping redis %s: %v after %d retries\n", url, err, retries+1)

--- a/pkg/database/redis.go
+++ b/pkg/database/redis.go
@@ -34,7 +34,7 @@ func initPool(host string, port int) (string, *redis.Pool) {
 		Dial: func() (redis.Conn, error) {
 			conn, err := redis.Dial("tcp", url)
 			for retries := 0; err != nil && retries < 5; retries++ {
-				time.Sleep((50 << retries) * time.Millisecond)
+				time.Sleep((10 << retries) * time.Millisecond)
 				if conn, err = redis.Dial("tcp", url); err == nil {
 					if _, err = conn.Do("PING"); err != nil {
 						log.Printf("ERROR: fail to ping redis %s: %v after %d retries\n", url, err, retries+1)
@@ -44,7 +44,6 @@ func initPool(host string, port int) (string, *redis.Pool) {
 				}
 			}
 			return conn, err
-
 		},
 	}
 	fmt.Printf("The url is %s and the pool is %v\n", url, pool)

--- a/pkg/database/redis.go
+++ b/pkg/database/redis.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/regionless-storage-service/pkg/config"
+	"github.com/regionless-storage-service/pkg/constants"
 )
 
 var (
@@ -33,9 +34,10 @@ func initPool(host string, port int) (string, *redis.Pool) {
 		MaxActive: 12000,
 		Dial: func() (redis.Conn, error) {
 			conn, err := redis.Dial("tcp", url)
-			for retries := 0; err != nil && retries < 5; retries++ {
+			for retries := 0; err != nil && retries < constants.RetryCount; retries++ {
 				log.Printf("ERROR: failed to init the redis %s connection with error %v after %d times\n", url, err, retries+1)
-				time.Sleep((10 << retries) * time.Millisecond)
+				interval := constants.RetryIntervalInMilliseconds << retries
+				time.Sleep(interval * time.Millisecond)
 				if conn, err = redis.Dial("tcp", url); err == nil {
 					if _, err = conn.Do("PING"); err != nil {
 						log.Printf("ERROR: failed to ping redis %s: %v after %d retries\n", url, err, retries+1)

--- a/scripts/setup_test_lab.sh
+++ b/scripts/setup_test_lab.sh
@@ -2,12 +2,14 @@
 set -euo pipefail
 
 launch_rkv_fn() {
+    echo 524288 | sudo tee /proc/sys/net/netfilter/nf_conntrack_max
     jaeger_vmip=$1
     cp /tmp/config.json ~/regionless-storage-service/cmd/http/config.json
     nohup ~/regionless-storage-service/main --jaeger-server=http://${jaeger_vmip}:14268 >/tmp/rkv.log 2>&1 &
 }
 
 config_ycsb_fn() {
+    echo 524288 | sudo tee /proc/sys/net/netfilter/nf_conntrack_max
     rkv_vmip=$1
     sudo sed -i '/rkv/d' /etc/hosts
     echo ${rkv_vmip} rkv | sudo tee -a /etc/hosts > /dev/null


### PR DESCRIPTION
Redis pooling might have stale connections which get timeout errors when dialling

To fix it, updated its dial function  to retry 5 times to bring back active connections. 

Also, found the netfilter rate limits in rkv and ycsb are 8192 since they are micro type servers, which drops connection from time to time

Updated the rate limit from 8192 to 524288 in the deployment scripts

Ran YCSB using 16 threads and load 500K key value pair successfully.


![image](https://user-images.githubusercontent.com/50841010/189301143-4e99435c-f3b8-4955-9561-f6a7af8d8524.png)


![image](https://user-images.githubusercontent.com/50841010/189300772-de8468ba-cb0d-4644-b5ba-149a86ff0d53.png)


