### PR TITLE
trivial: go-ycsb ami image refreshed as source code changes

### DIFF
--- a/scripts/test-lab.val.2xlarge
+++ b/scripts/test-lab.val.2xlarge
@@ -41,7 +41,7 @@ export JAEGER_VM_NAME=${NAME_TAG}-rkv-lab-jaeger
 ## of go-ycsb client
 export YCSB_REGION=us-west-2
 export YCSB_AZ=us-west-2b
-export YCSB_AMI=ami-03fadfb192c131dc0 	    #hw-ami-go-ycsb5
+export YCSB_AMI=ami-0adacc6121d78daba       #hw-ami-ycsb-6
 export YCSB_INSTANCE_TYPE=t2.2xlarge
 export YCSB_ROOT_DISK_VOLUME=16
 export YCSB_VM_NAME=${NAME_TAG}-rkv-lab-ycsb

--- a/scripts/test-lab.val.medium
+++ b/scripts/test-lab.val.medium
@@ -41,7 +41,7 @@ export JAEGER_VM_NAME=${NAME_TAG}-rkv-lab-jaeger
 ## of go-ycsb client
 export YCSB_REGION=us-west-2
 export YCSB_AZ=us-west-2b
-export YCSB_AMI=ami-03fadfb192c131dc0 	    #hw-ami-go-ycsb5
+export YCSB_AMI=ami-0adacc6121d78daba       #hw-ami-ycsb-6
 export YCSB_INSTANCE_TYPE=t2.medium
 export YCSB_ROOT_DISK_VOLUME=16
 export YCSB_VM_NAME=${NAME_TAG}-rkv-lab-ycsb

--- a/scripts/test-lab.val.micro
+++ b/scripts/test-lab.val.micro
@@ -41,7 +41,7 @@ export JAEGER_VM_NAME=${NAME_TAG}-rkv-lab-jaeger
 ## of go-ycsb client
 export YCSB_REGION=us-west-2
 export YCSB_AZ=us-west-2b
-export YCSB_AMI=ami-03fadfb192c131dc0 	    #hw-ami-go-ycsb5
+export YCSB_AMI=ami-0adacc6121d78daba       #hw-ami-ycsb-6
 export YCSB_INSTANCE_TYPE=t2.micro
 export YCSB_ROOT_DISK_VOLUME=16
 export YCSB_VM_NAME=${NAME_TAG}-rkv-lab-ycsb


### PR DESCRIPTION
Trivial PR, for perf test lab to use new AMI image that includes the recent code change of go-ycsb rkv driver.

This new AMI image was created manually at AWS management console. This customized AMI image is preferable as it has the built go-ycsb binary which can be used right away. Alternative is to create ec2 instance out of vanilla os image and have the (make/golang) tools installed and source code repo cloned and build - it actually takes quite a while as it has to fetch all the dependency modules of go-ycsb, which is quite time/bandwidth consuming.