### PR TITLE
new API: update key-value pair on top of assumed latest revision

### DIFF
--- a/pkg/index/key_index.go
+++ b/pkg/index/key_index.go
@@ -240,6 +240,16 @@ func (a *keyIndex) equal(b *keyIndex) bool {
 	return true
 }
 
+func (ki *keyIndex) update(main int64, sub int64, nodes []string, revAssumed int64) error {
+	revLatest := ki.modified.main
+	if revLatest != revAssumed {
+		return fmt.Errorf("the rev to assume is not the latest one")
+	}
+
+	ki.put(main, sub, nodes)
+	return nil
+}
+
 func (ki *keyIndex) String() string {
 	var s string
 	for _, g := range ki.generations {

--- a/pkg/index/key_index_test.go
+++ b/pkg/index/key_index_test.go
@@ -81,3 +81,99 @@ func TestPut(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdate(t *testing.T) {
+	tcs := []struct {
+		name                string
+		index               keyIndex
+		revToPut            Revision
+		revToAssume         int64
+		expectedModified    Revision
+		expectedGenerations []generation
+		expectedError       string
+	}{
+		{
+			name: "update rev on top of assumed one and succeed",
+			index: keyIndex{
+				key:      []byte("testkey"),
+				modified: Revision{main: 99, sub: 0, nodes: []string{"node2"}},
+				generations: []generation{{
+					ver:     2,
+					created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+					revs: []Revision{
+						{main: 98, sub: 0, nodes: []string{"node1"}},
+						{main: 99, sub: 0, nodes: []string{"node2"}},
+					},
+				}}},
+			revToPut:         Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+			revToAssume:      99,
+			expectedModified: Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+			expectedGenerations: []generation{{
+				ver:     3,
+				created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+				revs: []Revision{
+					{main: 98, sub: 0, nodes: []string{"node1"}},
+					{main: 99, sub: 0, nodes: []string{"node2"}},
+					{main: 100, sub: 0, nodes: []string{"node3"}},
+				},
+			},
+			},
+		},
+		{
+			name: "update stale rev and fail",
+			index: keyIndex{
+				key:      []byte("testkey"),
+				modified: Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+				generations: []generation{{
+					ver:     2,
+					created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+					revs: []Revision{
+						{main: 98, sub: 0, nodes: []string{"node1"}},
+						{main: 100, sub: 0, nodes: []string{"node3"}},
+					},
+				}}},
+			revToPut:         Revision{main: 101, sub: 0, nodes: []string{"node2"}},
+			revToAssume:      98,
+			expectedModified: Revision{main: 100, sub: 0, nodes: []string{"node3"}},
+			expectedGenerations: []generation{
+				{
+					ver:     2,
+					created: Revision{main: 98, sub: 0, nodes: []string{"node1"}},
+					revs: []Revision{
+						{main: 98, sub: 0, nodes: []string{"node1"}},
+						{main: 100, sub: 0, nodes: []string{"node3"}},
+					},
+				},
+			},
+			expectedError: "the rev to assume is not the latest one",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.index.update(tc.revToPut.main, tc.revToPut.sub, tc.revToPut.GetNodes(), tc.revToAssume)
+
+			if len(tc.expectedError) == 0 && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if len(tc.expectedError) != 0 {
+				if err == nil {
+					t.Errorf("test case should have failed but not")
+				}
+
+				if tc.expectedError != err.Error() {
+					t.Errorf("unexpected error message: %s", err)
+				}
+			}
+
+			if !reflect.DeepEqual(tc.index.modified, tc.expectedModified) {
+				t.Errorf("extecped modified rev %v, got %v", tc.expectedModified, tc.index.modified)
+			}
+
+			if !reflect.DeepEqual(tc.expectedGenerations, tc.index.generations) {
+				t.Errorf("extecped resultant generations %v, got %v", tc.expectedGenerations, tc.index.generations)
+			}
+		})
+	}
+}


### PR DESCRIPTION
adds new feature: k-v pair updated on condition of assumed latest revision. This is the feature requested by #64.

Client is able to specify the known revision assumed to be the latest one, while sending new key-value update request. rkv service will check the latest revision of key against the rev to be assumed; only go ahead to update if they match.

The issue having not clean up the wasted writes in case of error (even better to avoid such) is known, which also exist in regular (blind) put. this PR does not attempt to address it yet.

below is example session to use this feature.
```bash
$ curl -XPOST http://127.0.0.1:8090/kv -d '{"key":"a", "value":"aaa"}'
    The key value pair (a,aaa) has been saved as revision 1 at store1,store3,store4
$ curl -XPOST http://127.0.0.1:8090/kv -d '{"key":"a", "value":"aaa2"}'
    The key value pair (a,aaa2) has been saved as revision 3 at store1,store3,store4
$ curl -XPUT http://127.0.0.1:8090/kv?rev=1 -d '{"key":"a", "value":"aaa3"}'
    the rev to assume is not the latest one
$ curl -XPUT http://127.0.0.1:8090/kv?rev=3 -d '{"key":"a", "value":"aaa4"}'
    The key value pair (a,aaa4) has been saved as revision 7 at store1,store3,store4
$ curl http://127.0.0.1:8090/kv?key=a
    The value is ...
```